### PR TITLE
Locality sensitive hashing annotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ oxilangtag = {version="0.1.3", features=["serde"]}
 language-tags = "0.3.2"
 lazy_static = "1.4.0"
 oscar-io = "0.1.3"
+tlsh = {git="https://github.com/Uinelj/tlsh-rs", branch="fix-q3-panic"}
 
 [dev-dependencies]
 rand_distr = "0.4.2"

--- a/src/pipelines/oscardoc/pipeline.rs
+++ b/src/pipelines/oscardoc/pipeline.rs
@@ -216,7 +216,7 @@ impl OscarDoc {
                 .add(Box::new(TinyDocument::default()))
                 .add(Box::new(ShortSentences::default()))
                 .add(Box::new(Header::default()))
-                .add(Box::new(LSH::default()));
+                .add(Box::new(LSH::default()))
                 .add(Box::new(Noisy::default()));
 
             // TODO: Same here, we instantiate it once by shard

--- a/src/pipelines/oscardoc/pipeline.rs
+++ b/src/pipelines/oscardoc/pipeline.rs
@@ -36,7 +36,7 @@ use crate::pipelines::pipeline::Pipeline;
 use crate::sources::commoncrawl::Wet;
 use crate::transformers::{
     self, Annotate, Annotator, ContentDetector, Header, Noisy, ShortSentences, TinyDocument,
-    Transform,
+    Transform, LSH,
 };
 use log::{debug, error, info, log_enabled, warn};
 use oxilangtag::LanguageTag;
@@ -204,7 +204,8 @@ impl OscarDoc {
             .add(Box::new(TinyDocument::default()))
             .add(Box::new(ShortSentences::default()))
             .add(Box::new(Header::default()))
-            .add(Box::new(Noisy::default()));
+            .add(Box::new(Noisy::default()))
+            .add(Box::new(LSH::default()));
 
         // TODO: Same here, we instantiate it once by shard
         if let Some(path) = blocklist {

--- a/src/pipelines/oscardoc/types/document.rs
+++ b/src/pipelines/oscardoc/types/document.rs
@@ -9,10 +9,8 @@ use warc::BufferedBody;
 use warc::Record;
 use warc::WarcHeader;
 
-
 use crate::identifiers::identification::Identification as IdentificationGen;
 // use crate::identifiers::Identification;
-
 
 type Identification = IdentificationGen<String>;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -37,13 +35,16 @@ impl Metadata {
         }
     }
 
-    /// Set the metadata's annotation.
-    pub fn set_annotation(&mut self, annotation: String) {
+    pub fn add_annotation(&mut self, annotation: String) {
         match &mut self.annotation {
             Some(anno) => anno.push(annotation),
             None => self.annotation = Some(vec![annotation]),
         }
     }
+    /// Set the metadata's annotation.
+    // pub fn set_annotation(&mut self, annotation: String) {
+    //     self.annotation = Some(vec![annotation]);
+    // }
 
     /// Get a reference to the metadata's annotation.
     pub fn annotation(&self) -> Option<&Vec<String>> {

--- a/src/transformers/content_detector.rs
+++ b/src/transformers/content_detector.rs
@@ -52,7 +52,7 @@ impl<'a> Annotate<Document> for ContentDetector<'a> {
             if self.bl.detect_domain(&valid_url) || self.bl.detect_url(&valid_url) {
                 info!("Document {} flagged as adult", doc.warc_id());
                 doc.metadata_mut()
-                    .set_annotation(self.bl.kind().to_string());
+                    .add_annotation(self.bl.kind().to_string());
             }
         }
     }
@@ -80,7 +80,6 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert(WarcHeader::TargetURI, url.as_bytes().to_vec());
         let metadata = Metadata::default();
-        
 
         Document::new(content, headers, metadata)
     }

--- a/src/transformers/header.rs
+++ b/src/transformers/header.rs
@@ -42,7 +42,7 @@ impl Annotate<Document> for Header {
         // iterate over the header, counting short lines
         let short_lines_count = self.count_short_lines(doc.content().lines().take(nb_lines_header));
         if short_lines_count > treshold_lines {
-            doc.metadata_mut().set_annotation("header".to_string());
+            doc.metadata_mut().add_annotation("header".to_string());
         }
 
         // do the same in reverse order (to get footer)
@@ -50,7 +50,7 @@ impl Annotate<Document> for Header {
             self.count_short_lines(doc.content().lines().rev().take(nb_lines_header));
 
         if short_lines_count > treshold_lines {
-            doc.metadata_mut().set_annotation("footer".to_string());
+            doc.metadata_mut().add_annotation("footer".to_string());
         }
     }
 }

--- a/src/transformers/lsh.rs
+++ b/src/transformers/lsh.rs
@@ -1,0 +1,86 @@
+/*! Locality sensitive hashing !*/
+
+use oscar_io::oscar_doc::WarcHeaders;
+use tlsh::{BucketKind, ChecksumKind, TlshBuilder};
+
+use crate::pipelines::oscardoc::types::Document;
+use warc::WarcHeader;
+
+use super::Annotate;
+use log::warn;
+pub struct LSH {
+    builder: TlshBuilder,
+}
+
+impl LSH {
+    pub fn new(builder: TlshBuilder) -> Self {
+        Self { builder }
+    }
+}
+impl Annotate<Document> for LSH {
+    fn annotate(&self, doc: &mut Document) {
+        let mut builder = self.builder.clone();
+        builder.update(doc.content().as_bytes());
+        match builder.build() {
+            Ok(hash) => {
+                let annotation = format!("tlsh:{}", hash.hash());
+                doc.metadata_mut().add_annotation(annotation);
+            }
+            Err(e) => warn!(
+                "Could not compute a hash for document {:?}: {:?}",
+                String::from_utf8_lossy(
+                    doc.warc_headers()
+                        .get(&WarcHeader::RecordID)
+                        .unwrap_or(&vec![])
+                ),
+                e
+            ),
+        }
+    }
+}
+
+impl Default for LSH {
+    fn default() -> Self {
+        let mut builder = TlshBuilder::new(
+            BucketKind::Bucket256,
+            ChecksumKind::ThreeByte,
+            tlsh::Version::Version4,
+        );
+
+        Self::new(builder)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use tlsh::{BucketKind, ChecksumKind, TlshBuilder};
+
+    #[test]
+    fn test_tlsh() {
+        let s1 = "fooooooooooooooooooooooooooooooooooooooooooooooooo";
+        let s1 = r#"cvqlmd,cpqlzec;)à"ç!(àb"(!uyiuegfbnsoc,)az"à(!ç"#;
+
+        let mut builder = TlshBuilder::new(
+            BucketKind::Bucket256,
+            ChecksumKind::ThreeByte,
+            tlsh::Version::Version4,
+        );
+        builder.update(s1.as_bytes());
+        let tlsh1 = builder.build().unwrap();
+
+        let s2 = "Le Mallorquín ou Majorquin (Cavall Mallorquí en catalan) est une race de chevaux de selle à la robe noire, autochtone de Majorque, l'une des îles Baléares en Espagne, à laquelle il doit son nom. Il est très proche du cheval Minorquin, et souvent confondu avec lui. Vraisemblablement issu de chevaux celtiques et notamment du cheval catalan, il est introduit sur l'île de Majorque avec de nombreux croisements au XIXe siècle. La motorisation ayant raison de son développement, il manque de disparaître dans les années 1970.
+
+        aUne association d'éleveurs se mobilise en 1981 pour sauver la race, et obtient l'ouverture d'un stud-book en 1988. Il existe moins de 400 individus Mallorquíns recensés en 2012, mais leur utilisation dans les loisirs équestres les préserve désormais de l'extinction. Sobre et rustique, de taille moyenne et de constitution raffinée, le cheval Mallorquín reste essentiellement élevé à Majorque. ";
+        let mut builder = TlshBuilder::new(
+            BucketKind::Bucket256,
+            ChecksumKind::ThreeByte,
+            tlsh::Version::Version4,
+        );
+        builder.update(s2.as_bytes());
+        let tlsh2 = builder.build().unwrap();
+
+        // Calculate diff between s1 & s2, including length difference.
+        println!("{}", tlsh1.diff(&tlsh2, true));
+        // Calculate diff between s1 & s2, excluding length difference.
+        println!("{}", tlsh1.diff(&tlsh2, false));
+    }
+}

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -10,15 +10,16 @@ Transformers can either (or both) [Annotate] content or [Transform] it:
 mod annotate;
 mod content_detector;
 mod header;
+mod lsh;
+mod noisy;
 mod sentence_filter;
 mod tiny;
 mod transform;
-
-mod noisy;
 pub use annotate::Annotate;
 pub use annotate::Annotator;
 pub use content_detector::ContentDetector;
 pub use header::Header;
+pub use lsh::LSH;
 pub use noisy::Noisy;
 pub use sentence_filter::Conv;
 pub use sentence_filter::RemoveShortSentences;

--- a/src/transformers/noisy.rs
+++ b/src/transformers/noisy.rs
@@ -38,7 +38,7 @@ impl Annotate<Document> for Noisy {
 
                 // if count is more than what we consider to be the threshold, stop there
                 if nonletter_count > threshold {
-                    doc.metadata_mut().set_annotation("noisy".to_string());
+                    doc.metadata_mut().add_annotation("noisy".to_string());
                     break;
                 }
             } else {

--- a/src/transformers/sentence_filter.rs
+++ b/src/transformers/sentence_filter.rs
@@ -42,7 +42,7 @@ impl Annotate<Document> for ShortSentences {
         if nb_short_lines > threshold {
             debug!("record {} flagged for short sentences", doc.warc_id());
             doc.metadata_mut()
-                .set_annotation("short_sentences".to_string());
+                .add_annotation("short_sentences".to_string());
         }
     }
 }
@@ -384,7 +384,6 @@ baz
         .to_string();
         let headers = HashMap::new();
         let metadata = Metadata::default();
-        
 
         Document::new(content, headers, metadata)
     }

--- a/src/transformers/tiny.rs
+++ b/src/transformers/tiny.rs
@@ -8,7 +8,7 @@ pub struct TinyDocument {
 impl Annotate<Document> for TinyDocument {
     fn annotate(&self, doc: &mut Document) {
         if doc.content().lines().count() < self.threshold {
-            doc.metadata_mut().set_annotation("tiny".to_string())
+            doc.metadata_mut().add_annotation("tiny".to_string())
         }
     }
 }


### PR DESCRIPTION
Adds a TLSH hash value as annotation (when possible).

This aims to ease the computation of OSCAR diffs (each document has a URL+TLSH, which could help build a "similarity score" that would help identify similar pages throughout differrent OSCAR releases.